### PR TITLE
example.css has moved.

### DIFF
--- a/Chat/index.html
+++ b/Chat/index.html
@@ -3,7 +3,7 @@
   <title>Firebase Chat Example</title>
   <script type="text/javascript" src="https://cdn.firebase.com/v0/firebase.js"></script>
   <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js'></script>
-  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/css/example.css">
+  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/resources/tutorial/css/example.css">
 </head>
 <body>
 <div id='messagesDiv'></div>

--- a/Drawing/index.html
+++ b/Drawing/index.html
@@ -3,7 +3,7 @@
   <title>Firebase Collaborative Drawing Example</title>
   <script type="text/javascript" src="https://cdn.firebase.com/v0/firebase.js"></script>
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/css/example.css">
+  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/resources/tutorial/css/example.css">
 </head>
 <body>
 <h1>Firebase Real-time Drawing</h1>

--- a/Leaderboard/index.html
+++ b/Leaderboard/index.html
@@ -3,7 +3,7 @@
   <title>Firebase Leaderboard Example</title>
   <script type="text/javascript" src="https://cdn.firebase.com/v0/firebase.js"></script>
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/css/example.css">
+  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/resources/tutorial/css/example.css">
 </head>
 <body>
 <table id="leaderboardTable"></table>

--- a/Presence/index.html
+++ b/Presence/index.html
@@ -6,7 +6,7 @@
   <script type="text/javascript" src="https://cdn.firebase.com/v0/firebase.js"></script>
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
   <script type="text/javascript" src="https://www.firebase.com/js/libs/idle.js"></script>
-  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/css/example.css">
+  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/resources/tutorial/css/example.css">
 </head>
 <body>
 <div id="presenceDiv"></div>

--- a/Tetris/index.html
+++ b/Tetris/index.html
@@ -3,7 +3,7 @@
   <title>Tetris</title>
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
   <script type="text/javascript" src="https://cdn.firebase.com/v0/firebase.js"></script>
-  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/css/example.css">
+  <link rel="stylesheet" type="text/css" href="https://www.firebase.com/resources/tutorial/css/example.css">
 </head>
 
 <body class="tetris-body">


### PR DESCRIPTION
Before: https://rawgit.com/firebase/examples/master/Drawing/index.html (color palette invisible).
After: https://rawgit.com/cben/examples/master/Drawing/index.html
ditto for other examples.

Found the new URL via https://www.firebase.com/tutorial/#example/drawing

Consider adding example.css to this repo so it's self-contained.
